### PR TITLE
docs: adds `go run ` before go commands

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -20,4 +20,4 @@ Acesse o container o rodando o comando:
 docker compose exec go_app_dev bash
 ```
 
-Use os comandos `cmd/splitchunks/main.go` e `cmd/videoconverter/main.go` para rodar a aplicação, conforme a aula.
+Use os comandos `go run cmd/splitchunks/main.go` e `go run cmd/videoconverter/main.go` para rodar a aplicação, conforme a aula.


### PR DESCRIPTION
Adição do comando `go run` antes dos comandos recomendados no arquivo README.md do projeto golang.